### PR TITLE
Remove redundant objectsRef in handleClick

### DIFF
--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -169,7 +169,7 @@ const RequestPage = () => {
     const handleClick = (result) => {
       if (disabled) return;
 
-      const objects = objectsRef.current;
+      // const objects = objectsRef.current;
 
       const item = result?.[0];
 


### PR DESCRIPTION
## Summary
- In `RequestPage.renderForm`, `handleClick` was overwriting the outer `objects` (already derived from `values.objects`) with `objectsRef.current`. Since `renderForm` re-runs on every render, the outer closure value is already current — drop the inner reassignment so the dedupe + append uses the same `objects` reference as the rest of the function.

## Test plan
- [ ] Open a new/editable request, click an object on the map — it gets added to the objects list.
- [ ] Click the same object again — it is not duplicated.
- [ ] Click a second distinct object — both appear in the list.
- [ ] Open a read-only/approved request — clicking the map does not mutate the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)