### PR TITLE
Issue #2: 'Erdviniai duomenys (.geojson)' extract option

### DIFF
--- a/src/components/other/FileDownloadContainer.tsx
+++ b/src/components/other/FileDownloadContainer.tsx
@@ -7,6 +7,17 @@ export interface FileDownloadProps {
   showFileName?: boolean;
 }
 
+const getDownloadLabel = (url: string) => {
+  const lower = url.toLowerCase();
+  if (lower.endsWith(".geojson") || lower.endsWith(".json")) {
+    return buttonsTitles.downloadGeoJson;
+  }
+  if (lower.endsWith(".pdf")) {
+    return buttonsTitles.downloadPdf;
+  }
+  return buttonsTitles.download;
+};
+
 const FileDownloadContainer = ({ url, showFileName }: FileDownloadProps) => {
   if (url) {
     return (
@@ -19,7 +30,7 @@ const FileDownloadContainer = ({ url, showFileName }: FileDownloadProps) => {
           }}
         >
           <DownloadContainer target={"_blank"} href={url} download>
-            {buttonsTitles.download}
+            {getDownloadLabel(url)}
             <StyledIcon name={"download"} />
           </DownloadContainer>
         </Container>

--- a/src/components/other/FileDownloadContainer.tsx
+++ b/src/components/other/FileDownloadContainer.tsx
@@ -7,12 +7,20 @@ export interface FileDownloadProps {
   showFileName?: boolean;
 }
 
+const getPathSuffix = (raw: string) => {
+  try {
+    return new URL(raw).pathname.toLowerCase();
+  } catch (_) {
+    return raw.toLowerCase().split("?")[0];
+  }
+};
+
 const getDownloadLabel = (url: string) => {
-  const lower = url.toLowerCase();
-  if (lower.endsWith(".geojson") || lower.endsWith(".json")) {
+  const path = getPathSuffix(url);
+  if (path.endsWith(".geojson") || path.endsWith(".json")) {
     return buttonsTitles.downloadGeoJson;
   }
-  if (lower.endsWith(".pdf")) {
+  if (path.endsWith(".pdf")) {
     return buttonsTitles.downloadPdf;
   }
   return buttonsTitles.download;
@@ -29,7 +37,7 @@ const FileDownloadContainer = ({ url, showFileName }: FileDownloadProps) => {
             e.stopPropagation();
           }}
         >
-          <DownloadContainer target={"_blank"} href={url} download>
+          <DownloadContainer href={url} download>
             {getDownloadLabel(url)}
             <StyledIcon name={"download"} />
           </DownloadContainer>

--- a/src/components/other/FilesToDownload.tsx
+++ b/src/components/other/FilesToDownload.tsx
@@ -7,12 +7,20 @@ export interface FilesToDownloadProps {
   showFileName?: boolean;
 }
 
+const getPathSuffix = (raw: string) => {
+  try {
+    return new URL(raw).pathname.toLowerCase();
+  } catch (_) {
+    return raw.toLowerCase().split("?")[0];
+  }
+};
+
 const getDownloadLabel = (url: string) => {
-  const lower = url.toLowerCase();
-  if (lower.endsWith(".geojson") || lower.endsWith(".json")) {
+  const path = getPathSuffix(url);
+  if (path.endsWith(".geojson") || path.endsWith(".json")) {
     return buttonsTitles.downloadGeoJson;
   }
-  if (lower.endsWith(".pdf")) {
+  if (path.endsWith(".pdf")) {
     return buttonsTitles.downloadPdf;
   }
   return buttonsTitles.download;
@@ -30,7 +38,7 @@ const FilesToDownload = ({ url, showFileName }: FilesToDownloadProps) => {
           e.stopPropagation();
         }}
       >
-        <DownloadContainer target={"_blank"} href={url} download>
+        <DownloadContainer href={url} download>
           {getDownloadLabel(url)}
           <StyledIcon name={"download"} />
         </DownloadContainer>

--- a/src/components/other/FilesToDownload.tsx
+++ b/src/components/other/FilesToDownload.tsx
@@ -7,6 +7,17 @@ export interface FilesToDownloadProps {
   showFileName?: boolean;
 }
 
+const getDownloadLabel = (url: string) => {
+  const lower = url.toLowerCase();
+  if (lower.endsWith(".geojson") || lower.endsWith(".json")) {
+    return buttonsTitles.downloadGeoJson;
+  }
+  if (lower.endsWith(".pdf")) {
+    return buttonsTitles.downloadPdf;
+  }
+  return buttonsTitles.download;
+};
+
 const FilesToDownload = ({ url, showFileName }: FilesToDownloadProps) => {
   if (!url) return <></>;
 
@@ -20,7 +31,7 @@ const FilesToDownload = ({ url, showFileName }: FilesToDownloadProps) => {
         }}
       >
         <DownloadContainer target={"_blank"} href={url} download>
-          {buttonsTitles.download}
+          {getDownloadLabel(url)}
           <StyledIcon name={"download"} />
         </DownloadContainer>
       </Container>

--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -58,15 +58,19 @@ export interface RequestPayload {
   canValidate?: boolean;
   data?: {
     extended?: any;
+    format?: string;
   };
   geom?: any;
 }
 
-const requestDataTypes = ['false', 'true'];
+const REQUEST_FORMAT_GEOJSON = 'geojson';
+
+const requestDataTypes = ['false', 'true', REQUEST_FORMAT_GEOJSON];
 
 const requestDataTypeLabels = {
   false: 'Pagrindiniai duomenys (.pdf)',
   true: 'Išplėstiniai duomenys (.pdf)',
+  [REQUEST_FORMAT_GEOJSON]: 'Erdviniai duomenys (.geojson)',
 };
 
 const RequestPage = () => {
@@ -132,7 +136,10 @@ const RequestPage = () => {
           id: item?.cadastralId,
         };
       }),
-      data: { extended: extended === 'true' },
+      data:
+        extended === REQUEST_FORMAT_GEOJSON
+          ? { extended: false, format: 'GEOJSON' }
+          : { extended: extended === 'true' },
     };
 
     if (isNew(id)) {
@@ -147,7 +154,10 @@ const RequestPage = () => {
     agreeWithConditions: disabled || false,
     purposeValue: request?.purposeValue || '',
     purpose: request?.purpose || PurposeTypes.TERRITORIAL_PLANNING_DOCUMENT,
-    extended: request?.data?.extended?.toString() || 'false',
+    extended:
+      request?.data?.format === 'GEOJSON'
+        ? REQUEST_FORMAT_GEOJSON
+        : request?.data?.extended?.toString() || 'false',
   };
 
   const isApproved = isEqual(request?.status, StatusTypes.APPROVED);

--- a/src/pages/Requests/functions.tsx
+++ b/src/pages/Requests/functions.tsx
@@ -23,10 +23,13 @@ export const mapRequestFilters = (filters: RequestFilters) => {
         }),
       });
 
-    filters?.requestDataType &&
-      (params.data = JSON.stringify({
-        extended: filters.requestDataType.id === RequestDataType.EXTENDED_DATA,
-      }));
+    if (filters?.requestDataType) {
+      params.data = JSON.stringify(
+        filters.requestDataType.id === RequestDataType.GEOJSON
+          ? { format: 'GEOJSON' }
+          : { extended: filters.requestDataType.id === RequestDataType.EXTENDED_DATA },
+      );
+    }
 
     filters?.category && (params.category = filters.category.id);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,6 +226,7 @@ export interface Request {
   data?: {
     unverified?: boolean;
     extended?: boolean;
+    format?: string;
   };
   geom?: any;
   agreeWithConditions?: boolean;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -266,4 +266,10 @@ export enum PurposeTypes {
 export enum RequestDataType {
   BASIC_DATA = 'BASIC_DATA',
   EXTENDED_DATA = 'EXTENDED_DATA',
+  GEOJSON = 'GEOJSON',
+}
+
+export enum RequestFormat {
+  PDF = 'PDF',
+  GEOJSON = 'GEOJSON',
 }

--- a/src/utils/texts.ts
+++ b/src/utils/texts.ts
@@ -429,6 +429,7 @@ export const formObjectTypeLabels = {
 export const requestDataTypeLabels = {
   [RequestDataType.BASIC_DATA]: 'Pagrindiniai duomenys (.pdf)',
   [RequestDataType.EXTENDED_DATA]: 'Išplėstiniai duomenys (.pdf)',
+  [RequestDataType.GEOJSON]: 'Erdviniai duomenys (.geojson)',
 };
 
 export const reverseFormObjectTypeLabels = {

--- a/src/utils/texts.ts
+++ b/src/utils/texts.ts
@@ -199,6 +199,8 @@ export const menuLabels = {
 };
 export const buttonsTitles = {
   download: 'Atsisiųsti',
+  downloadPdf: 'Atsisiųsti PDF',
+  downloadGeoJson: 'Atsisiųsti GeoJSON',
   or: 'arba',
   forgotPassword: 'Pamiršau slaptažodį',
   login: 'Prisijungti',


### PR DESCRIPTION
## Summary
Adds the third option to the **Išrašo duomenų tipas** dropdown on the request creation form: *Erdviniai duomenys (.geojson)*. Selecting it sends \`data.format='GEOJSON'\` (with \`extended=false\`) to the API.

- \`RequestDataType.GEOJSON\` enum entry → automatically appears in the list page filter dropdown via the existing \`getRequestDataTypes\` mapper.
- \`Request.tsx\` — third dropdown option, payload mapping in \`handleSubmit\`, initial-value mapping for editing existing requests.
- \`Requests/functions.tsx\` — list filter rewrites to \`{ format: 'GEOJSON' }\` when GeoJSON is selected (instead of the \`{ extended: bool }\` shape used by the PDF options).
- Type updates in \`types.ts\` to allow optional \`data.format\`.

## Pairs with
biip-uetk-api PR — implements the actual GeoJSON file generation when the admin approves the request.

## Test plan
- [ ] Open the new request page, choose *Erdviniai duomenys (.geojson)*, submit — verify the network payload includes \`data: { extended: false, format: 'GEOJSON' }\`.
- [ ] Reload an existing GEOJSON request — dropdown should reopen on the GeoJSON option.
- [ ] In the requests list, filter by *Erdviniai duomenys (.geojson)* — verify it returns only GeoJSON-format requests.
- [ ] Existing basic / extended PDF flows: still create with the previous payload shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)