### PR TITLE
Issue #5: object-category and territory-mode pickers on request form

### DIFF
--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -19,19 +19,31 @@ import FormPageWrapper from '../components/wrappers/FormikFormPageWrapper';
 import { useAppSelector } from '../state/hooks';
 import { device } from '../styles';
 import { ColumnOne, ColumnTwo, Container } from '../styles/GenericStyledComponents';
-import { mapsHost, PurposeTypes, StatusTypes } from '../utils/constants';
+import {
+  ANY_OBJECT_CATEGORY,
+  FormObjectType,
+  mapsHost,
+  PurposeTypes,
+  StatusTypes,
+  TerritoryType,
+} from '../utils/constants';
 import { getLocationList, handleErrorFromServerToast, isNew } from '../utils/functions';
 import { useGetCurrentProfile } from '../utils/hooks';
 import { purposeTypesOptions } from '../utils/options';
 import { slugs } from '../utils/routes';
 import {
   formLabels,
+  formObjectTypeLabels,
   inputLabels,
+  objectCategoryLabel,
   pageTitles,
   purposeTypeLabels,
   requestHistoryStatusLabels,
+  territoryTypeLabels,
   url,
 } from '../utils/texts';
+import RadioOptions from '../components/buttons/RadioOptionts';
+import TextField from '../components/fields/TextField';
 import { validateRequest } from '../utils/validation';
 
 export interface RequestProps {
@@ -45,6 +57,10 @@ export interface RequestProps {
   extended?: any;
   geom?: any;
   agreeWithConditions: boolean;
+  objectCategory?: string;
+  territoryType?: TerritoryType | string;
+  municipalities?: string;
+  basins?: string;
 }
 
 export interface RequestPayload {
@@ -58,6 +74,10 @@ export interface RequestPayload {
   canValidate?: boolean;
   data?: {
     extended?: any;
+    category?: string;
+    territoryType?: string;
+    municipalities?: string[];
+    basins?: string[];
   };
   geom?: any;
 }
@@ -122,7 +142,39 @@ const RequestPage = () => {
   });
 
   const handleSubmit = async (values: RequestProps) => {
-    const { agreeWithConditions, extended, objects, ...rest } = values;
+    const {
+      agreeWithConditions,
+      extended,
+      objects,
+      objectCategory,
+      territoryType,
+      municipalities,
+      basins,
+      ...rest
+    } = values;
+
+    const data: RequestPayload['data'] = { extended: extended === 'true' };
+
+    if (objectCategory && objectCategory !== ANY_OBJECT_CATEGORY) {
+      data.category = objectCategory;
+    }
+
+    if (territoryType) {
+      data.territoryType = territoryType;
+      if (territoryType === TerritoryType.MUNICIPALITY && municipalities?.trim()) {
+        data.municipalities = municipalities
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+      }
+      if (territoryType === TerritoryType.BASIN && basins?.trim()) {
+        data.basins = basins
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+      }
+    }
+
     const params: RequestPayload = {
       ...rest,
       notifyEmail: currentProfile?.email || userEmail || '',
@@ -132,7 +184,7 @@ const RequestPage = () => {
           id: item?.cadastralId,
         };
       }),
-      data: { extended: extended === 'true' },
+      data,
     };
 
     if (isNew(id)) {
@@ -148,6 +200,10 @@ const RequestPage = () => {
     purposeValue: request?.purposeValue || '',
     purpose: request?.purpose || PurposeTypes.TERRITORIAL_PLANNING_DOCUMENT,
     extended: request?.data?.extended?.toString() || 'false',
+    objectCategory: (request?.data as any)?.category || ANY_OBJECT_CATEGORY,
+    territoryType: (request?.data as any)?.territoryType || TerritoryType.FREE_DRAW,
+    municipalities: ((request?.data as any)?.municipalities || []).join(', '),
+    basins: ((request?.data as any)?.basins || []).join(', '),
   };
 
   const isApproved = isEqual(request?.status, StatusTypes.APPROVED);
@@ -232,7 +288,51 @@ const RequestPage = () => {
                     return requestDataTypeLabels[e];
                   }}
                 />
+                <SelectField
+                  disabled={disabled}
+                  label={inputLabels.objectCategory}
+                  value={values.objectCategory}
+                  name={'objectCategory'}
+                  onChange={(e) => handleChange('objectCategory', e)}
+                  options={[ANY_OBJECT_CATEGORY, ...Object.keys(FormObjectType)]}
+                  getOptionLabel={(e) => objectCategoryLabel(e)}
+                />
               </Row>
+              <Row columns={1}>
+                <RadioOptions
+                  disabled={disabled}
+                  label={inputLabels.territoryType}
+                  name="territoryType"
+                  value={values.territoryType as string}
+                  onChange={(value) => handleChange('territoryType', value)}
+                  options={Object.entries(territoryTypeLabels).map(([value, label]) => ({
+                    value,
+                    label,
+                  }))}
+                />
+              </Row>
+              {values.territoryType === TerritoryType.MUNICIPALITY && (
+                <Row columns={1}>
+                  <TextField
+                    disabled={disabled}
+                    label={inputLabels.municipalities}
+                    placeholder="pvz. Vilniaus m., Kauno r."
+                    value={values.municipalities || ''}
+                    onChange={(e: string) => handleChange('municipalities', e)}
+                  />
+                </Row>
+              )}
+              {values.territoryType === TerritoryType.BASIN && (
+                <Row columns={1}>
+                  <TextField
+                    disabled={disabled}
+                    label={inputLabels.basins}
+                    placeholder="pvz. Nemuno, Neries"
+                    value={values.basins || ''}
+                    onChange={(e: string) => handleChange('basins', e)}
+                  />
+                </Row>
+              )}
             </SimpleContainer>
 
             <SimpleContainer title={formLabels.objectList}>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -267,3 +267,11 @@ export enum RequestDataType {
   BASIC_DATA = 'BASIC_DATA',
   EXTENDED_DATA = 'EXTENDED_DATA',
 }
+
+export enum TerritoryType {
+  MUNICIPALITY = 'MUNICIPALITY',
+  BASIN = 'BASIN',
+  FREE_DRAW = 'FREE_DRAW',
+}
+
+export const ANY_OBJECT_CATEGORY = 'ALL';

--- a/src/utils/texts.ts
+++ b/src/utils/texts.ts
@@ -270,6 +270,10 @@ export const formLabels = {
 };
 export const inputLabels = {
   requestType: 'Išrašo duomenų tipas',
+  objectCategory: 'Objektų kategorija',
+  territoryType: 'Teritorijos pasirinkimo būdas',
+  municipalities: 'Savivaldybės',
+  basins: 'Baseinai / pabaseiniai',
   generating: 'Išrašas kuriamas',
   hydrostaticId: 'Hidrostatinio unikalus identifikatorius',
   attribute: 'Atributas',
@@ -429,6 +433,17 @@ export const formObjectTypeLabels = {
 export const requestDataTypeLabels = {
   [RequestDataType.BASIC_DATA]: 'Pagrindiniai duomenys (.pdf)',
   [RequestDataType.EXTENDED_DATA]: 'Išplėstiniai duomenys (.pdf)',
+};
+
+export const territoryTypeLabels = {
+  MUNICIPALITY: 'Savivaldybės teritorija',
+  BASIN: 'Upių baseinas / pabaseinis',
+  FREE_DRAW: 'Laisvai pažymėta teritorija',
+};
+
+export const objectCategoryLabel = (key: string) => {
+  if (key === 'ALL') return 'Visi objektai';
+  return formObjectTypeLabels[key] || key;
 };
 
 export const reverseFormObjectTypeLabels = {


### PR DESCRIPTION
## Summary
Implements the front-end side of UETK extract request issue #5: lets the requester narrow the request before submitting.

- **Object category dropdown** (*Objektų kategorija*) — UETK object types plus a default *Visi objektai*. Stored as \`data.category\`. The api's existing \`filterCategory\` scope on requests already filters by this field, so this works end-to-end out of the box.
- **Territory mode radio** (*Teritorijos pasirinkimo būdas*) — three options:
  - **Savivaldybės teritorija** → text field for municipalities
  - **Upių baseinas / pabaseinis** → text field for basins
  - **Laisvai pažymėta teritorija** → reuses the existing \`MapField\` geom flow (no UI change for this mode)
  The mode is stored as \`data.territoryType\`; the picked municipalities/basins go into \`data.municipalities\` / \`data.basins\` (string arrays).
- Defaults are backwards-compatible: \`ANY_OBJECT_CATEGORY\` + \`FREE_DRAW\` match how existing requests behave.

## Out of scope (follow-up backend work)
- Municipality/basin pickers are **plain text fields** for now. Replacing them with proper async multi-select dropdowns needs a real data source — the api would need to expose endpoints like \`GET /objects/municipalities\` and \`GET /objects/basins\`. I left a TODO in the commit body so it's easy to find.
- The api ignores \`data.municipalities\` / \`data.basins\` / \`data.territoryType\` today — they're persisted in the jsonb column but nothing acts on them yet. The category field is the only one that flows all the way through to filtering.
- *Marking the requested territory in the generated extract* (the third sub-bullet of the issue) is a template/PDF change — out of frontend scope.

## Test plan
- [ ] New request page renders the new category dropdown and territory radio.
- [ ] Pick a category other than 'Visi objektai' → submit → confirm \`data.category\` appears in the network payload.
- [ ] Pick MUNICIPALITY → text field appears → submit → \`data.territoryType='MUNICIPALITY'\` and \`data.municipalities=[...]\` in payload.
- [ ] Pick BASIN → similar.
- [ ] Pick FREE_DRAW → existing map drawing still works, geom is set on the request.
- [ ] Reload an existing request — values pre-populate from \`data\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)