### PR TITLE
Add Geodatabase (GDB) extract option to data-acquisition flow

### DIFF
--- a/src/components/other/FileDownloadContainer.tsx
+++ b/src/components/other/FileDownloadContainer.tsx
@@ -29,6 +29,9 @@ const getDownloadLabel = (url: string) => {
   if (path.endsWith(".pdf")) {
     return buttonsTitles.downloadPdf;
   }
+  if (path.endsWith(".zip")) {
+    return buttonsTitles.downloadGdb;
+  }
   return buttonsTitles.download;
 };
 

--- a/src/components/other/FilesToDownload.tsx
+++ b/src/components/other/FilesToDownload.tsx
@@ -29,6 +29,9 @@ const getDownloadLabel = (url: string) => {
   if (path.endsWith(".pdf")) {
     return buttonsTitles.downloadPdf;
   }
+  if (path.endsWith(".zip")) {
+    return buttonsTitles.downloadGdb;
+  }
   return buttonsTitles.download;
 };
 

--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -58,15 +58,19 @@ export interface RequestPayload {
   canValidate?: boolean;
   data?: {
     extended?: any;
+    format?: string;
   };
   geom?: any;
 }
 
-const requestDataTypes = ['false', 'true'];
+const REQUEST_FORMAT_GDB = 'gdb';
+
+const requestDataTypes = ['false', 'true', REQUEST_FORMAT_GDB];
 
 const requestDataTypeLabels = {
   false: 'Pagrindiniai duomenys (.pdf)',
   true: 'Išplėstiniai duomenys (.pdf)',
+  [REQUEST_FORMAT_GDB]: 'Erdviniai duomenys (Geodatabase, .zip)',
 };
 
 const RequestPage = () => {
@@ -132,7 +136,10 @@ const RequestPage = () => {
           id: item?.cadastralId,
         };
       }),
-      data: { extended: extended === 'true' },
+      data:
+        extended === REQUEST_FORMAT_GDB
+          ? { extended: false, format: 'GDB' }
+          : { extended: extended === 'true' },
     };
 
     if (isNew(id)) {
@@ -147,7 +154,10 @@ const RequestPage = () => {
     agreeWithConditions: disabled || false,
     purposeValue: request?.purposeValue || '',
     purpose: request?.purpose || PurposeTypes.TERRITORIAL_PLANNING_DOCUMENT,
-    extended: request?.data?.extended?.toString() || 'false',
+    extended:
+      request?.data?.format === 'GDB'
+        ? REQUEST_FORMAT_GDB
+        : request?.data?.extended?.toString() || 'false',
   };
 
   const isApproved = isEqual(request?.status, StatusTypes.APPROVED);

--- a/src/pages/Requests/functions.tsx
+++ b/src/pages/Requests/functions.tsx
@@ -24,9 +24,11 @@ export const mapRequestFilters = (filters: RequestFilters) => {
       });
 
     if (filters?.requestDataType) {
-      params.data = JSON.stringify({
-        extended: filters.requestDataType.id === RequestDataType.EXTENDED_DATA,
-      });
+      params.data = JSON.stringify(
+        filters.requestDataType.id === RequestDataType.GDB
+          ? { format: 'GDB' }
+          : { extended: filters.requestDataType.id === RequestDataType.EXTENDED_DATA },
+      );
     }
 
     filters?.category && (params.category = filters.category.id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,6 +227,7 @@ export interface Request {
   data?: {
     unverified?: boolean;
     extended?: boolean;
+    format?: string;
   };
   geom?: any;
   agreeWithConditions?: boolean;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -266,4 +266,10 @@ export enum PurposeTypes {
 export enum RequestDataType {
   BASIC_DATA = 'BASIC_DATA',
   EXTENDED_DATA = 'EXTENDED_DATA',
+  GDB = 'GDB',
+}
+
+export enum RequestFormat {
+  PDF = 'PDF',
+  GDB = 'GDB',
 }

--- a/src/utils/texts.ts
+++ b/src/utils/texts.ts
@@ -200,6 +200,7 @@ export const menuLabels = {
 export const buttonsTitles = {
   download: 'Atsisiųsti',
   downloadPdf: 'Atsisiųsti PDF',
+  downloadGdb: 'Atsisiųsti Geodatabase (ZIP)',
   or: 'arba',
   forgotPassword: 'Pamiršau slaptažodį',
   login: 'Prisijungti',
@@ -430,6 +431,7 @@ export const formObjectTypeLabels = {
 export const requestDataTypeLabels = {
   [RequestDataType.BASIC_DATA]: 'Pagrindiniai duomenys (.pdf)',
   [RequestDataType.EXTENDED_DATA]: 'Išplėstiniai duomenys (.pdf)',
+  [RequestDataType.GDB]: 'Erdviniai duomenys (Geodatabase, .zip)',
 };
 
 export const reverseFormObjectTypeLabels = {


### PR DESCRIPTION
## Summary

Adds the third dropdown option **\"Erdviniai duomenys (Geodatabase, .zip)\"** on \`/duomenu-gavimas\`. Stacked on top of #81 (the GeoJSON-removal cleanup). Per-request scope: the ZIP contains only the cadastralIds the user picked, not the full UETK bulk download.

The backend assembles the GeoJSON → calls biip-tools \`/gdb\` → uploads the returned ZIP to MinIO → user downloads through the same \`generatedFile\` UI as PDF.

## Changes

- \`constants.ts\` — \`RequestDataType.GDB\` + \`RequestFormat\` enum (PDF | GDB)
- \`texts.ts\` — dropdown label + \`buttonsTitles.downloadGdb\` (\"Atsisiųsti Geodatabase (ZIP)\")
- \`Request.tsx\` — third option in the data-type SelectField; submit + initialValues map dropdown \`'gdb'\` ↔ \`data.format = 'GDB'\`
- \`Requests/functions.tsx\` — list filter maps GDB → \`{format:'GDB'}\` for the JSONB containment filter on the API
- \`types.ts\` — \`data.format\` passthrough on the request payload type
- \`FileDownloadContainer.tsx\` + \`FilesToDownload.tsx\` — \`.zip\` suffix → \`downloadGdb\` label

## Companion PRs

- biip-tools#14 — \`/gdb\` endpoint (must deploy first)
- biip-uetk-api add-gdb-extract-format — backend \`generateGdb\` action
- biip-admin-web uetk/add-gdb-extract-format — admin filter / table column

## Test plan

- [x] \`yarn build\` clean
- [ ] After all deploys: pick Geodatabase + a few cadastralIds → submit → admin approves → \"Atsisiųsti Geodatabase (ZIP)\" button appears → ZIP opens in QGIS and shows only the requested objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)